### PR TITLE
feat: Use named colors instead on color codes when available

### DIFF
--- a/exporter.json
+++ b/exporter.json
@@ -1,24 +1,21 @@
 {
   "id": "io.supernova.ios-swiftui",
   "name": "iOS SwiftUI",
-  "description": "iOS SwiftUI token and style exporter",
+  "description": "iOS UIColor token exporter for figma veriables",
   "source_dir": "src",
-  "version": "1.2.5",
+  "version": "2.0.0",
   "usesBrands": true,
+  "usesThemes": true,
   "tags": [
     "iOS",
-    "SwiftUI",
+    "UIColor",
     "Tokens",
-    "Styles",
     "Colors",
-    "Borders",
-    "Gradients",
-    "Measures",
     "Typography",
-    "Radii"
+    "theme"
   ],
-  "author": "Vaclav Lustek",
-  "organization": "Supernova",
+  "author": "Justin Champappilly",
+  "organization": "Mindvalley",
   "homepage": "https://supernova.io",
   "config": {
     "output": "output.json",
@@ -26,7 +23,7 @@
     "js": "src/functions.js"
   },
   "engines": {
-    "pulsar": "1.0.0",
-    "supernova": "1.0.0"
+    "pulsar": "latest",
+    "supernova": "latest"
   }
 }

--- a/src/exported_files/colors.pr
+++ b/src/exported_files/colors.pr
@@ -7,28 +7,33 @@ public extension UIColor {
     }
 {* Polulate the color map with all variants of colors *}
 {[ const brand = ds.currentBrand() /]}
+{[ const themesData = ds.allThemes(brand.id) /]}
 {[ const colorTokensTree = ds.tokenGroupTreeByType("Color", brand.id) /]}
-{[ traverse colorTokensTree property subgroups into colorTokenGroup ]}
-    {[ let fullTokenGroupPath = createFullTokenGroupPath(colorTokenGroup) /]}
-    {[ const colorTokenInGroups = ds.tokensByGroupId(colorTokenGroup.id) /]}
-    {{ groupTokensByName(colorTokenInGroups, fullTokenGroupPath) }}
-{[/]}
+{{ groupTokensByName(themesData); }}
 {* Generete light and dark colors as static computed variables *}
 {[ traverse colorTokensTree property subgroups into colorTokenGroup ]}
-    {[ const colorTokenInGroups = ds.tokensByGroupId(colorTokenGroup.id) /]}
-    {[ for colorToken in colorTokenInGroups ]}
-    {[if isColorStylesToken(colorToken) ]}
-    {[ let lightColor = getColorsFor(colorToken.name, "LightUI") /]}
-    {[ let darkColor = getColorsFor(colorToken.name, "DarkUI") /]}
-    {[ if (colorToken.description && colorToken.description.count() !== 0) ]}
-    {{ createDocumentationComment(colorToken.description, "    ") }}
-    {[/]}
+{[ const colorTokenInGroups = ds.tokensByGroupId(colorTokenGroup.id) /]}
+{[ for colorToken in colorTokenInGroups ]}
+{[if isColorStylesToken(colorToken) ]}
+{[if isColorThemed(colorToken.name) ]}
+{[ let lightColor = getColorsFor(colorToken.name, "Light") /]}
+{[ let darkColor = getColorsFor(colorToken.name, "Dark") /]}
+{[ inject "documentation" context colorToken/]}
 
     static let {[ inject "token_name" context colorToken /]} = UIColor { (traitCollection: UITraitCollection) -> UIColor in
-        return isDark(traitCollection) ? {[ inject "color" context darkColor.color /]} : {[ inject "color" context lightColor.color /]}
+        return isDark(traitCollection) ? {[ inject "conditional_color_name" context darkColor /]} : {[ inject "conditional_color_name" context lightColor /]}
 
     }
+{[ else ]}
+{[ let lightColor = getColorsFor(colorToken.name, "LightUI") /]}
 
+{[ inject "documentation" context colorToken/]}
+
+    static var {[ inject "token_name" context colorToken /]} : UIColor { 
+         {[ inject "color" context lightColor.color /]}
+        
+    }
+{[/]}   
 {[/]} 
 {[/]}  
 {[/]}

--- a/src/utility/conditional_color_name.pr
+++ b/src/utility/conditional_color_name.pr
@@ -1,0 +1,6 @@
+{[ let colorName = getNameForColor(context.color.hex) /]}
+{[if (colorName)]}
+.{{colorName.camelcased(false)}}
+{[ else ]}
+{[ inject "color" context context.color /]}
+{[/]}

--- a/src/utility/documentation.pr
+++ b/src/utility/documentation.pr
@@ -1,0 +1,5 @@
+{[ if (context.description && context.description.count() !== 0) ]}
+
+{{ createDocumentationComment(context.description, "    ") }}
+
+{[/]}


### PR DESCRIPTION
This PR fixes some issue with themed colors not being picked up properly by moving to a different API `allThemes()` instead of `allTokensByGroupID()`